### PR TITLE
Mobile no floating

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,8 @@
   ],
   "dependencies": {
     "d2l-colors": "^2.0.0",
-    "polymer": "^1.5.0"
+    "polymer": "^1.5.0",
+    "iron-media-query": "^1.0.8"
   },
   "devDependencies": {
     "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.1.5",

--- a/d2l-button.html
+++ b/d2l-button.html
@@ -53,12 +53,6 @@
 				background-color: var(--d2l-color-celestuba);
 				@apply(--d2l-button-primary-hover);
 			}
-			@media(max-width: 554px) {
-				:host {
-					padding-left: 1rem;
-					padding-right: 1rem;
-				}
-			}
 		</style>
 		<content></content>
 	</template>

--- a/d2l-floating-buttons.html
+++ b/d2l-floating-buttons.html
@@ -90,8 +90,6 @@
 			_spacer: null,
 
 			attached: function() {
-				window.addEventListener('resize', this._reposition.bind(this));
-				window.addEventListener('scroll', this._reposition.bind(this));
 				this._isRTL = (getComputedStyle(this._container).direction === 'rtl');
 				this._reposition();
 			},
@@ -102,6 +100,10 @@
 			},
 
 			ready: function() {
+				this._reposition = this._reposition.bind(this);
+				window.addEventListener('resize', this._reposition);
+				window.addEventListener('scroll', this._reposition);
+
 				this._container = this.$$('.d2l-floating-buttons-container');
 				this._spacer = this.$$('.d2l-floating-buttons-spacer');
 

--- a/d2l-floating-buttons.html
+++ b/d2l-floating-buttons.html
@@ -90,6 +90,8 @@
 			_spacer: null,
 
 			attached: function() {
+				window.addEventListener('resize', this._reposition);
+				window.addEventListener('scroll', this._reposition);
 				this._isRTL = (getComputedStyle(this._container).direction === 'rtl');
 				this._reposition();
 			},
@@ -101,9 +103,6 @@
 
 			ready: function() {
 				this._reposition = this._reposition.bind(this);
-				window.addEventListener('resize', this._reposition);
-				window.addEventListener('scroll', this._reposition);
-
 				this._container = this.$$('.d2l-floating-buttons-container');
 				this._spacer = this.$$('.d2l-floating-buttons-spacer');
 

--- a/d2l-floating-buttons.html
+++ b/d2l-floating-buttons.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
+<link rel="import" href="../iron-media-query/iron-media-query.html">
 <link rel="import" href="d2l-button-shared-styles.html">
 
 <dom-module id="d2l-floating-buttons">
@@ -67,6 +68,8 @@
 			}
 		</style>
 
+		<iron-media-query query="(max-width: 555px)" query-matches="{{_isAtMost555px}}"></iron-media-query>
+
 		<div class="d2l-floating-buttons-container">
 			<div><content></content></div>
 		</div>
@@ -77,6 +80,10 @@
 	<script>
 		Polymer({
 			is: 'd2l-floating-buttons',
+
+			properties: {
+				_isAtMost555px: Boolean
+			},
 
 			_container: null,
 			_isRTL: false,
@@ -112,10 +119,6 @@
 				return this._container.classList.contains('d2l-floating-buttons-floating');
 			},
 
-			_getViewportWidth() {
-				return Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
-			},
-
 			_reposition: function() {
 
 				var containerRect = this._container.getBoundingClientRect();
@@ -135,8 +138,7 @@
 
 				var innerContainer = this._container.querySelector('div');
 
-
-				if ((this._getViewportWidth() < 555) ||
+				if ((this._isAtMost555px) ||
 						((containerTop + containerRect.height) <= viewBottom)
 					) {
 

--- a/d2l-floating-buttons.html
+++ b/d2l-floating-buttons.html
@@ -40,14 +40,6 @@
 				margin-left: var(--d2l-button-spacing);
 				margin-right: 0;
 			}
-			@media(max-width: 554px) {
-				.d2l-floating-buttons-container ::content button {
-					display: block;
-					margin-left: 0;
-					margin-right: 0;
-					width: 100%;
-				}
-			}
 
 			@keyframes d2l-floating-buttons-animation {
 				0% {
@@ -120,6 +112,10 @@
 				return this._container.classList.contains('d2l-floating-buttons-floating');
 			},
 
+			_getViewportWidth() {
+				return Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
+			},
+
 			_reposition: function() {
 
 				var containerRect = this._container.getBoundingClientRect();
@@ -139,7 +135,10 @@
 
 				var innerContainer = this._container.querySelector('div');
 
-				if ((containerTop + containerRect.height) <= viewBottom) {
+
+				if ((this._getViewportWidth() < 555) ||
+						((containerTop + containerRect.height) <= viewBottom)
+					) {
 
 					this._container.classList.remove('d2l-floating-buttons-floating');
 					if (!this._isRTL) {
@@ -149,6 +148,7 @@
 					}
 
 					this._spacer.style.display = 'none';
+					innerContainer.style.width = 'auto';
 
 				} else {
 

--- a/test/floating-buttons.html
+++ b/test/floating-buttons.html
@@ -12,12 +12,14 @@
 		<test-fixture id="d2l-floating-buttons-fixture">
 			<template>
 				<d2l-floating-buttons>
-					<button is="d2l-button">Make more Beer!</button>
+					<button is="d2l-button">Make more Beer ON A PHONE!</button>
 				</d2l-floating-buttons>
 			</template>
 		</test-fixture>
 
 		<script>
+
+		var atMost555px = Math.max(document.documentElement.clientWidth, window.innerWidth || 0) <= 555;
 
 		describe('<d2l-floating-buttons>', function() {
 
@@ -31,7 +33,7 @@
 				expect(floatingButtons.isFloating()).to.be.false;
 			});
 
-			it('floats when bottons move below the fold', function() {
+			it('floats when buttons move below the fold and not mobile', function() {
 
 				var content = document.createElement('div');
 				floatingButtons.parentNode.insertBefore(content, floatingButtons);
@@ -39,7 +41,7 @@
 				content.style.height = '10000px';
 				floatingButtons._reposition();
 
-				expect(floatingButtons.isFloating()).to.be.true;
+				expect(floatingButtons.isFloating()).to.equal(!atMost555px);
 
 			});
 
@@ -58,7 +60,7 @@
 
 			});
 
-			it('repositions as a result of resize event', function() {
+			it('repositions as a result of resize event and not mobile', function() {
 
 				var content = document.createElement('div');
 				floatingButtons.parentNode.insertBefore(content, floatingButtons);
@@ -66,11 +68,11 @@
 				content.style.height = '10000px';
 				window.dispatchEvent(new Event('resize'));
 
-				expect(floatingButtons.isFloating()).to.be.true;
+				expect(floatingButtons.isFloating()).to.equal(!atMost555px);
 
 			});
 
-			it('repositions as a result of scroll event', function() {
+			it('repositions as a result of scroll event and not mobile', function() {
 
 				var content = document.createElement('div');
 				floatingButtons.parentNode.insertBefore(content, floatingButtons);
@@ -78,7 +80,7 @@
 				content.style.height = '10000px';
 				window.dispatchEvent(new Event('scroll'));
 
-				expect(floatingButtons.isFloating()).to.be.true;
+				expect(floatingButtons.isFloating()).to.equal(!atMost555px);
 
 			});
 

--- a/test/index-mobile.html
+++ b/test/index-mobile.html
@@ -7,18 +7,15 @@
 		<script src="../../web-component-tester/browser.js"></script>
 		<style>
 		  #subsuites {
-		    width: 900px;
+		    width: 300px;
 		  }
 		</style>
 	</head>
 	<body>
 		<script>
 		WCT.loadSuites([
-			'button.html',
-			'button.html?dom=shadow',
 			'floating-buttons.html',
-			'floating-buttons.html?dom=shadow',
-			'index-mobile.html'
+			'floating-buttons.html?dom=shadow'
 		]);
 		</script>
 	</body>


### PR DESCRIPTION
@dbatiste cause you know the wc floating buttons. :)
@dlockhart more for the mobile testing setup.

I looked into Galen a little bit and chatted with Anthony quickly.  It looks cool, and could help us with perceptual testing, but I needed to have WCT run in different size viewports.  So Galen didn't seem the right way to go for that (might be like taking a sledge hammer to a small nail).

I found setting the subset iframe width in a separate 'mobile' test index was the easiest/cleanest.  I didn't find any good examples online (such as in an iron component).  In fact I thought Google's own testing of iron-media-query to be lacking.

Needing to test like this is probably somewhat rare-ish, as normally you would just rely on CSS media queries and then something like Galen makes more sense.  In this case I felt I had to rely on JS determining the viewport size because of how widths/paddings/etc are set inline (so I'm using iron-media-query for that).